### PR TITLE
Treat webencodings like html5lib and bleach

### DIFF
--- a/tensorboard/build.sh
+++ b/tensorboard/build.sh
@@ -96,8 +96,8 @@ mkdir -p tensorboard/_vendor
 touch tensorboard/_vendor/__init__.py
 cp -LR "${RUNFILES}/org_html5lib/html5lib" tensorboard/_vendor
 cp -LR "${RUNFILES}/org_mozilla_bleach/bleach" tensorboard/_vendor
+cp -LR "${RUNFILES}/org_pythonhosted_webencodings/webencodings" tensorboard/_vendor
 cp -LR "${RUNFILES}/org_tensorflow_serving_api/tensorflow_serving" tensorboard/_vendor
-
 chmod -R u+w,go+r .
 
 find tensorboard -name \*.py |
@@ -106,6 +106,8 @@ find tensorboard -name \*.py |
     s/^from html5lib/from tensorboard._vendor.html5lib/
     s/^import bleach$/from tensorboard._vendor import bleach/
     s/^from bleach/from tensorboard._vendor.bleach/
+    s/^import webencodings$/from tensorboard._vendor import webencodings/
+    s/^from webencodings/from tensorboard._vendor.webencodings/
     s/from tensorflow_serving/from tensorboard._vendor.tensorflow_serving/
   '
 # install the package

--- a/tensorboard/meta.yaml
+++ b/tensorboard/meta.yaml
@@ -46,8 +46,6 @@ requirements:
     - six >={{six}}
     - werkzeug >={{werkzeug}}
     - futures >=3.1.1  # [py27]
-    # this one should be vendored.  It is a dep of html5lib, which tensorboard vendors.
-    - webencodings
     # reported missing dep on OSX.  Apply to all, just to be safe.
     - wheel
 


### PR DESCRIPTION
Apply tensorboard commit:
https://github.com/tensorflow/tensorboard/commit/6f0a81380c78a1a48c7b30023240f6d59208fab5#diff-169a7c1f7467c03dfccb95cedebad74a
for the changes to build_pip_package.sh into tensorboard build.sh

This way webencodings will be built into TensorBoard like html5lib
and bleach and not be a dependency.