### PR TITLE
Remove freeze_graph CLI test; update README

### DIFF
--- a/tensorflow-base-gpu/README.md
+++ b/tensorflow-base-gpu/README.md
@@ -1,37 +1,69 @@
+# tensorflow-base-gpu
+
 To build a conda tensorflow package with GPU support
 
-* Build the required Docker containers:
+## Linux
 
-    Dockerfiles can be found at: https://github.com/jjhelmus/docker-images
+- Build the required Docker containers:
 
-    CUDA  9.0: pkg_build_cos6_cuda90
-    CUDA  9.2: pkg_build_cos6_cuda92
-    CUDA 10.0: pkg_build_cos6_cuda100
+    Dockerfiles can be found at: https://github.com/conda/conda-concourse-ci/tree/master/docker/gpu
 
-* Start the docker container using:
+    - CUDA 9.0: `pkg_build_cos6_cuda90`
+    - CUDA 9.2: `pkg_build_cos6_cuda92`
+    - CUDA 10.0: `pkg_build_cos6_cuda100`
+
+- Start the docker container using:
 
     ```
     sudo nvidia-docker run -v `pwd`:/io -it pkg_build_cos6_cuda100
     ```
 
-* Create a symlink for libcuda.so.1
+- Create a symlink for `libcuda.so.1`
 
     ```
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
     ```
 
-* Update conda and conda-build, and navigate to the recipe root folder.
+- Open *Anaconda Prompt*. Update `conda` and `conda-build`, and navigate to the recipe root folder.
 
-    Modify conda_build_config.yaml in this directory to specifiy the
-    CUDA, CuDNN, compiler and python versions.
+    - Update the `conda_build_config.yaml` files for your build (there may be several `conda_build_config.yaml` files you will need to update at different directory levels, starting from the `aggregate` level down to your specific tensorflow recipe directory). Be sure to specifiy the CUDA, CuDNN, compiler and python versions.
 
-    To start a build use:
-
+    - To start a build use:
     ```
     conda build .
     ```
 
-    To time the build and log the build output use:
+    - To time the build and log the build output use:
     ```
     time conda build . 2>&1 | tee ../tf_build_gpu.log
     ```
+
+## Windows
+
+- Use *Microsoft Remote Desktop* to log into a Windows GPU-enabled machine in the Concourse build cluster.
+
+- Copy or clone the tensorflow recipes you need to build into a local directory. (As of 12/23/2020, you will likely need the whole `tensorflow_recipes` directory and its contents.)
+
+- Open *Anaconda Prompt*. Update `conda` and `conda-build`, and navigate to the recipe root folder.
+
+    - Update the `conda_build_config.yaml` files for your build (there may be several `conda_build_config.yaml` files you will need to update at different directory levels, starting from the `aggregate` level down to your specific tensorflow recipe directory). Be sure to specifiy the CUDA, CuDNN, compiler and python versions.
+
+    - To start a build use:
+    ```
+    conda build . --croot=C:\b --no-build-id > PATH_WHERE_YOU_WANT_TO_SAVE_LOGFILE 2>&1
+
+    EXAMPLE:
+    conda build . --croot=C:\b --no-build-id > C:\Users\builder\pyim\tf_build_logfile_0.txt 2>&1
+    ```
+
+### Error handling
+
+- `FATAL: Command line too long (34263 > 32768):  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=c:\\ci\\tensorflow-base_1607630317667\\bazel -Xverify:none -Djava.util.logging.config.file=c:\\ci\\tensorflow-base_1607630317667\\bazel\\javalog.properties -Dcom.google.devtools.build.lib.util.LogHandlerQuerier.class=com.google.devtools.build.lib.util.SimpleLogHandler$HandlerQuerier -XX:-MaxFDLimit
+...`
+    - Windows has a command line length limit that `bazel` is known to violate.
+    - **RESOLUTION**: Make sure to use the `--croot=C:\b` and `--no-build-id` parameters in your `conda-build` commmand to shorten the commands as much as possible.
+
+- `mktemp: failed to create directory via template ‘/c/t/tmp.XXXXXXXXXX’: No such file or directory`
+    - This is likely coming from the `./bazel-bin/tensorflow/tools/pip_package/build_pip_package` command, which tries to create a temp directory when it runs.
+    - **RESOLUTION**: In the local `C:` directory, create a directory called `t`, so you end up with a directory at `C:\t`. Re-run the `conda-build` command; it should now be able create the `/c/t/tmp.XXXXXXXXXX` file.
+

--- a/tensorflow-base-gpu/meta.yaml
+++ b/tensorflow-base-gpu/meta.yaml
@@ -103,7 +103,6 @@ test:
   files:
     - gpu_test.py
   commands:
-    - freeze_graph --help
     - saved_model_cli --help
     - tflite_convert --help     # [not win]
     - toco_from_protos --help   # [not win]


### PR DESCRIPTION
As of v2.0.0, the **tensorflow** project removed the `freeze_graph` CLI command. This PR removes the test for this. More info here: https://github.com/tensorflow/tensorflow/blob/master/RELEASE.md#breaking-changes-6

This PR also updates the README for the `tensorflow-base-gpu` recipe, adding details for the Windows GPU builds.