### PR TITLE
Release 2.6.0

### DIFF
--- a/tensorboard/meta.yaml
+++ b/tensorboard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorboard" %}
-{% set version = "2.5.0" %}
+{% set version = "2.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/py3/t/tensorboard/tensorboard-{{ version }}-py3-none-any.whl
-  sha256: e167460085b6528956b33bab1c970c989cdce47a6616273880733f5e7bde452e
+  sha256: f7dac4cdfb52d14c9e3f74585ce2aaf8e6203620a864e51faf84988b09f7bbdb
 
 build:
   number: 0

--- a/tensorflow-base-cpu-linwin/0004-loosen-requirements.patch
+++ b/tensorflow-base-cpu-linwin/0004-loosen-requirements.patch
@@ -2,7 +2,7 @@ Index: work/tensorflow/tools/pip_package/setup.py
 ===================================================================
 --- work.orig/tensorflow/tools/pip_package/setup.py
 +++ work/tensorflow/tools/pip_package/setup.py
-@@ -78,21 +78,21 @@ REQUIRED_PACKAGES = [
+@@ -78,22 +78,22 @@ REQUIRED_PACKAGES = [
      # NOTE: As numpy has releases that break semver guarantees and several other
      # deps depend on numpy without an upper bound, we must install numpy before
      # everything else.
@@ -11,6 +11,7 @@ Index: work/tensorflow/tools/pip_package/setup.py
      # Install other dependencies
      'absl-py ~= 0.10',
      'astunparse ~= 1.6.3',
+     'clang ~= 5.0',
 -    'flatbuffers ~= 1.12.0',
 +    'flatbuffers ~= 1.12',
      'google_pasta ~= 0.2',
@@ -33,11 +34,11 @@ Index: work/tensorflow/tools/pip_package/setup.py
      # These packages need to be pinned exactly as newer versions are
      # incompatible with the rest of the ecosystem
      'gast == 0.4.0',
-@@ -104,7 +104,7 @@ REQUIRED_PACKAGES = [
-     'tensorflow-estimator >= 2.5.0rc0 , < 2.6.0',
-     # TODO(scottzhu): OSS keras hasn't been formally released yet.
-     # Use keras-nightly at the moment.
--    'keras-nightly ~= 2.5.0.dev',
+@@ -103,7 +103,7 @@ REQUIRED_PACKAGES = [
+     # When updating these, please also update the nightly versions below
+     'tensorboard ~= 2.6',
+     'tensorflow_estimator ~= 2.6',
+-    'keras ~= 2.6',
 +    'keras >= 2.4.0',
  ]
  

--- a/tensorflow-base-cpu-linwin/build_win.sh
+++ b/tensorflow-base-cpu-linwin/build_win.sh
@@ -87,23 +87,15 @@ echo "" | ./configure
 # Windows. This can be mitigated by keeping the global build matrix contents to
 # the absolute minimum.
 BUILD_OPTS="
---verbose_failures
---logging=6
---subcommands
 --config=opt
 --define=override_eigen_strong_inline=true
 --define=no_tensorflow_py_deps=true
 ${BAZEL_MKL_OPT}"
 
 ${LIBRARY_BIN}/bazel --output_base $SRC_DIR/../bazel --batch build -c opt ${BUILD_OPTS} \
-    --action_env="PYTHON_BIN_PATH=${PYTHON}" \
-    --action_env="PYTHON_LIB_PATH=${SP_DIR}" \
-    --python_path="${PYTHON}" \
-    --define=PREFIX="$PREFIX" \
-    --define=LIBDIR="$PREFIX/lib" \
-    --define=INCLUDEDIR="$PREFIX/include" \
     --copt=-D_copysign="copysign" \
-    --host_copt=-D_copysign="copysign" --cxxopt=-D_copysign="copysign" \
+    --host_copt=-D_copysign="copysign" \
+    --cxxopt=-D_copysign="copysign" \
     --host_cxxopt=-D_copysign="copysign" \
     //tensorflow/tools/pip_package:build_pip_package || exit $?
 
@@ -115,11 +107,11 @@ ${LIBRARY_BIN}/bazel --output_base $SRC_DIR/../bazel --batch build -c opt ${BUIL
 # export _param_file="/c/users/$USER/_bazel_$USER/xxxxxxxx/execroot/org_tensorflow/bazel-out/x64_windows-opt/bin/tensorflow/lite/toco/python/_tensorflow_wrap_toco.so-2.params"
 # while true; do if [ -f $_param_file ]; then sed -i 's,^/WHOLEARCHIVE:\(.*external.*\),\1,' $_param_file; echo done; break; else sleep 1; fi; done
 
-PY_TEST_DIR="$SRC_DIR/py_test_dir"
+PY_TEST_DIR="${SRC_DIR}/py_test_dir"
 rm -fr ${PY_TEST_DIR}
 mkdir -p ${PY_TEST_DIR}
-cmd /c "mklink /J $(cygpath -w ${PY_TEST_DIR})\\tensorflow) .\\tensorflow"
-./bazel-bin/tensorflow/tools/pip_package/build_pip_package "$(cygpath -w ${PY_TEST_DIR})"
+cmd //c "mklink /J $(cygpath -w ${PY_TEST_DIR})\\tensorflow) .\\tensorflow"
+./bazel-bin/tensorflow/tools/pip_package/build_pip_package.exe "$(cygpath -w ${PY_TEST_DIR})"
 
 PIP_NAME=$(ls ${PY_TEST_DIR}/tensorflow-*.whl)
 # python -m pip install ${PIP_NAME} --no-deps -vv --ignore-installed

--- a/tensorflow-base-cpu-linwin/conda_build_config.yaml
+++ b/tensorflow-base-cpu-linwin/conda_build_config.yaml
@@ -1,9 +1,7 @@
-# Builds fail on linux with gcc 7.x, see
-# https://github.com/tensorflow/tensorflow/issues/25323
 c_compiler_version:    # [linux and not aarch64]
-  - 5.4                # [linux and not aarch64]
+  - 7.5                # [linux and not aarch64]
 cxx_compiler_version:  # [linux and not aarch64]
-  - 5.4                # [linux and not aarch64]
+  - 7.5                # [linux and not aarch64]
 cxx_compiler:  # [win]
   - vs2019     # [win]
 c_compiler:    # [win]

--- a/tensorflow-base-cpu-linwin/def_bazelrc
+++ b/tensorflow-base-cpu-linwin/def_bazelrc
@@ -1,3 +1,5 @@
+startup --output_user_root=C:/tmp
+
 build --define framework_shared_object=true
 
 # For workaround https://github.com/bazelbuild/bazel/issues/8772 with Bazel >= 0.29.1

--- a/tensorflow-base-cpu-linwin/meta.yaml
+++ b/tensorflow-base-cpu-linwin/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.0" %}
+{% set version = "2.6.0" %}
 
 # This is the recipe for the "mkl" and "eigen" variants of tensorflow-base
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: tensorflow-{{ version }}.tar.gz
   url: https://github.com/tensorflow/tensorflow/archive/v{{ version }}.tar.gz
-  sha256: 233875ea27fc357f6b714b2a0de5f6ff124b50c1ee9b3b41f9e726e9e677b86c
+  sha256: 41b32eeaddcbc02b0583660bcf508469550e4cd0f86b22d2abe72dfebeacde0f
   patches:
     - 0004-loosen-requirements.patch
     - tensorflow_win_zip64.patch                            # [win]
@@ -35,6 +35,9 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - git
+    - patch       # [unix]
+    - m2-patch    # [win]
     # required here for all OS's, and ALSO below for windows
     - bazel >=3.7.2
     - aws-sdk-cpp
@@ -106,8 +109,8 @@ requirements:
     - sqlite
     - snappy
     - typing_extensions >=3.7.4
-    - tensorboard >=2.5.0,<2.6
-    - tensorflow-estimator >=2.5.0,<2.6
+    - tensorboard >=2.6.0,<2.7
+    - tensorflow-estimator >=2.6.0,<2.7
   run:
     - python
     - absl-py >=0.10.0
@@ -130,8 +133,8 @@ requirements:
     - gast ==0.4.0
     - {{ pin_compatible('scipy', max_pin=None) }}
     - flatbuffers
-    - tensorboard >=2.5.0,<2.6
-    - tensorflow-estimator >=2.5.0,<2.6
+    - tensorboard >=2.6.0,<2.7
+    - tensorflow-estimator >=2.6.0,<2.7
 test:
   imports:
     - tensorflow

--- a/tensorflow-base-cpu-linwin/meta.yaml
+++ b/tensorflow-base-cpu-linwin/meta.yaml
@@ -62,6 +62,7 @@ requirements:
     - zip          # [not win]
     - m2-unzip     # [win]
     - m2-zip       # [win]
+    - m2-perl      # [win]
     - nsync
     # requirements specified by the package itself
     - astor >=0.7.1
@@ -91,7 +92,7 @@ requirements:
     - h5py >=3.1.0
     - keras-preprocessing >=1.1.2
     # has run_exports, doesn't need a run dep below
-    - mklml            # [win and tflow_variant == 'mkl']
+    # - mklml            # [win and tflow_variant == 'mkl']
     - numpy >=1.20  # [not aarch64]
     - numpy >=1.19  # [aarch64]
     - opt_einsum 3.3.0.*

--- a/tensorflow-base-gpu/0004-loosen-requirements.patch
+++ b/tensorflow-base-gpu/0004-loosen-requirements.patch
@@ -2,7 +2,7 @@ Index: work/tensorflow/tools/pip_package/setup.py
 ===================================================================
 --- work.orig/tensorflow/tools/pip_package/setup.py
 +++ work/tensorflow/tools/pip_package/setup.py
-@@ -78,21 +78,21 @@ REQUIRED_PACKAGES = [
+@@ -78,22 +78,22 @@ REQUIRED_PACKAGES = [
      # NOTE: As numpy has releases that break semver guarantees and several other
      # deps depend on numpy without an upper bound, we must install numpy before
      # everything else.
@@ -11,6 +11,7 @@ Index: work/tensorflow/tools/pip_package/setup.py
      # Install other dependencies
      'absl-py ~= 0.10',
      'astunparse ~= 1.6.3',
+     'clang ~= 5.0',
 -    'flatbuffers ~= 1.12.0',
 +    'flatbuffers ~= 1.12',
      'google_pasta ~= 0.2',
@@ -33,11 +34,11 @@ Index: work/tensorflow/tools/pip_package/setup.py
      # These packages need to be pinned exactly as newer versions are
      # incompatible with the rest of the ecosystem
      'gast == 0.4.0',
-@@ -104,7 +104,7 @@ REQUIRED_PACKAGES = [
-     'tensorflow-estimator >= 2.5.0rc0 , < 2.6.0',
-     # TODO(scottzhu): OSS keras hasn't been formally released yet.
-     # Use keras-nightly at the moment.
--    'keras-nightly ~= 2.5.0.dev',
+@@ -103,7 +103,7 @@ REQUIRED_PACKAGES = [
+     # When updating these, please also update the nightly versions below
+     'tensorboard ~= 2.6',
+     'tensorflow_estimator ~= 2.6',
+-    'keras ~= 2.6',
 +    'keras >= 2.4.0',
  ]
  

--- a/tensorflow-base-gpu/build_win.sh
+++ b/tensorflow-base-gpu/build_win.sh
@@ -133,7 +133,7 @@ ${LIBRARY_BIN}/bazel --output_base $SRC_DIR/../bazel --batch build -c opt $BUILD
 PY_TEST_DIR="$SRC_DIR/py_test_dir"
 rm -fr ${PY_TEST_DIR}
 mkdir -p ${PY_TEST_DIR}
-cmd /c "mklink /J $(cygpath -w ${PY_TEST_DIR})\\tensorflow .\\tensorflow"
+cmd //c "mklink /J $(cygpath -w ${PY_TEST_DIR})\\tensorflow .\\tensorflow"
 
 rm -rf /c/t/tmp.XXXXXXXXXX
 mkdir -p /c/t/tmp.XXXXXXXXXX

--- a/tensorflow-base-gpu/def_bazelrc
+++ b/tensorflow-base-gpu/def_bazelrc
@@ -1,3 +1,5 @@
+startup --output_user_root=C:/tmp
+
 build --define framework_shared_object=true
 
 # For workaround https://github.com/bazelbuild/bazel/issues/8772 with Bazel >= 0.29.1

--- a/tensorflow-base-gpu/meta.yaml
+++ b/tensorflow-base-gpu/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.0" %}
+{% set version = "2.6.0" %}
 
 # This is the recipe for the "gpu" variant of tensorflow-base
 package:
@@ -8,7 +8,7 @@ package:
 source:
   fn: tensorflow-{{ version }}.tar.gz
   url: https://github.com/tensorflow/tensorflow/archive/v{{ version }}.tar.gz
-  sha256: 233875ea27fc357f6b714b2a0de5f6ff124b50c1ee9b3b41f9e726e9e677b86c
+  sha256: 41b32eeaddcbc02b0583660bcf508469550e4cd0f86b22d2abe72dfebeacde0f
   patches:
     - 0004-loosen-requirements.patch
     - tensorflow_win_zip64.patch                            # [win]
@@ -38,6 +38,9 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - git
+    - patch       # [unix]
+    - m2-patch    # [win]
     # required here for all OS's, and ALSO below for windows
     - bazel >=3.7.2
     - aws-sdk-cpp
@@ -111,8 +114,8 @@ requirements:
     - sqlite
     - snappy
     - typing_extensions >=3.7.4
-    - tensorboard >=2.5.0,<2.6
-    - tensorflow-estimator >=2.5.0,<2.6
+    - tensorboard >=2.6.0,<2.7
+    - tensorflow-estimator >=2.6.0,<2.7
     # GPU requirements
     - cudatoolkit {{ cudatoolkit }}*
     - cudnn {{ cudnn }}*
@@ -140,8 +143,8 @@ requirements:
     - gast ==0.4.0
     - {{ pin_compatible('scipy', max_pin=None) }}
     - flatbuffers
-    - tensorboard >=2.5.0,<2.6
-    - tensorflow-estimator >=2.5.0,<2.6
+    - tensorboard >=2.6.0,<2.7
+    - tensorflow-estimator >=2.6.0,<2.7
     # GPU dependencies
     - cudatoolkit {{ cudatoolkit }}*
     - cudnn {{ cudnn }}*

--- a/tensorflow-estimator/meta.yaml
+++ b/tensorflow-estimator/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.5.0" %}
+{% set version = "2.6.0" %}
 
 package:
   name: tensorflow-estimator
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/py2.py3/t/tensorflow-estimator/tensorflow_estimator-{{ version }}-py2.py3-none-any.whl
-  sha256: d1fe76dee8b1dcab865d807a0246da0a9c4a635b1eba6e9545bf216c3aad6955
+  sha256: cf78528998efdb637ac0abaf525c929bf192767544eb24ae20d9266effcf5afd
 
 build:
   number: 0

--- a/tensorflow/conda_build_config_linux_64_cpu.yaml
+++ b/tensorflow/conda_build_config_linux_64_cpu.yaml
@@ -1,11 +1,11 @@
 # configuration for linux-64 eigen and mkl variants
 full_base_version:
-  - "2.5.0 eigen_py37h2b86b3d_0"
-  - "2.5.0 eigen_py38h2b86b3d_0"
-  - "2.5.0 eigen_py39h2b86b3d_0"
-  - "2.5.0 mkl_py37h35b2a3d_0"
-  - "2.5.0 mkl_py38h35b2a3d_0"
-  - "2.5.0 mkl_py39h35b2a3d_0"
+  - "2.6.0 eigen_py37ha9cc040_0"
+  - "2.6.0 eigen_py38ha9cc040_0"
+  - "2.6.0 eigen_py39ha9cc040_0"
+  - "2.6.0 mkl_py37h3d85931_0"
+  - "2.6.0 mkl_py38h3d85931_0"
+  - "2.6.0 mkl_py39h3d85931_0"
 
 select_version:
   - "2.2.0 eigen"

--- a/tensorflow/conda_build_config_win_cpu.yaml
+++ b/tensorflow/conda_build_config_win_cpu.yaml
@@ -1,11 +1,11 @@
 # configuration for win-64 eigen and mkl variants
 full_base_version:
-  - "2.5.0 eigen_py37h03e61e6_0"
-  - "2.5.0 eigen_py38h03e61e6_0"
-  - "2.5.0 eigen_py39h03e61e6_0"
-  - "2.5.0 mkl_py37h9201259_0"
-  - "2.5.0 mkl_py38h9201259_0"
-  - "2.5.0 mkl_py39h9201259_0"
+  - "2.6.0 eigen_py37h03e61e6_0"
+  - "2.6.0 eigen_py38h03e61e6_0"
+  - "2.6.0 eigen_py39h03e61e6_0"
+  - "2.6.0 mkl_py37h9201259_0"
+  - "2.6.0 mkl_py38h9201259_0"
+  - "2.6.0 mkl_py39h9201259_0"
 
 select_version:
   - "2.2.0 eigen"

--- a/tensorflow/meta.yaml
+++ b/tensorflow/meta.yaml
@@ -1,5 +1,5 @@
-{% set version = "2.5.0" %}
-{% set tb_version = "2.5.0" %}
+{% set version = "2.6.0" %}
+{% set tb_version = "2.6.0" %}
 
 package:
   name: tensorflow


### PR DESCRIPTION
Recipe updates for the CPU variants of TensorFlow for version 2.6.0. Notable changes items:

- The dependencies of the packages did not update between 2.5.0 and 2.6.0.
- GCC 7 works now.
- Most of the changes in build_win.sh came from v2.5.0 packages in **defaults**.
- Windows GPU is not yet building, but a majority of the updates are there.