### PR TITLE
Fix tensorboard dependency on tensorboard-data-server.

### DIFF
--- a/tensorboard/meta.yaml
+++ b/tensorboard/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: f7dac4cdfb52d14c9e3f74585ce2aaf8e6203620a864e51faf84988b09f7bbdb
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script:
     - python -m pip install --no-deps --ignore-installed ./tensorboard-{{ version }}-py3-none-any.whl
@@ -33,6 +33,7 @@ requirements:
     - grpcio >=1.24.3
     - google-auth-oauthlib ==0.4.1
     - tensorboard-plugin-wit >=1.6.0
+    - tensorboard-data-server >=0.6.0,<0.7.0
 
 test:
   imports:


### PR DESCRIPTION
The `tensorboard-data-server` package provides a new flag `--load-fast` that only has an implementation on **linux-64** and **osx-64**. All other platforms only provide a shell module that errors if it gets invoked.

[A bit more about it can be read in the initial update to tensorboard.](https://github.com/tensorflow/tensorboard/pull/4676)

I am open-minded about this update to `tensorboard`, but `tensorboard-data-server` is available in **defaults** now.