### PR TITLE
Upgrade `keras` and `tensorboard` to 2.9.0

### DIFF
--- a/keras/meta.yaml
+++ b/keras/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "keras" %}
-{% set version = "2.8.0" %}
+{% set version = "2.9.0" %}
 {% set major_minor = version.rsplit('.', 1)[0] %}
 
 package:
@@ -8,9 +8,9 @@ package:
 
 source:
   - url: https://pypi.io/packages/py2.py3/k/keras/keras-{{ version }}-py2.py3-none-any.whl
-    sha256: 744d39dc6577dcd80ff4a4d41549e92b77d6a17e0edd58a431d30656e29bc94e
+    sha256: 55911256f89cfc9343c9fbe4b61ec45a2d33d89729cbe1ab9dcacf8b07b8b6ab
   - url: https://raw.githubusercontent.com/keras-team/keras/v{{ version }}/LICENSE
-    sha256: ebc07b279109d4bd5e58fe06f54e8f8aee8ba1024b77b222bc04214ae6f56348
+    sha256: 58d1e17ffe5109a7ae296caafcadfdbe6a7d176f0bc4ab01e12a689b0499d8bd
 
 build:
   number: 0
@@ -27,14 +27,20 @@ requirements:
     - python
     - pyyaml
     - keras-preprocessing  >=1.1.2
+  run_constrained:
     # Other dependencies (such as h5py, numpy, ...) in their correct versions
     # will be pulled in by tensorflow-base.
     - tensorflow-base  {{ major_minor }}.*
 
+test:
+  requires:
+    - pip
+  commands:
+    - pip check
+
 about:
   home: https://github.com/keras-team/keras
-  license: MIT
-  license_family: MIT
+  license: Apache-2.0
   license_file: LICENSE
   summary: Deep Learning Library for Theano and TensorFlow
   description: |

--- a/keras/meta.yaml
+++ b/keras/meta.yaml
@@ -49,7 +49,7 @@ about:
     TensorFlow or Theano. It was developed with a focus on enabling
     fast experimentation. Being able to go from idea to result with
     the least possible delay is key to doing good research.
-  doc_url: http://keras.io
+  doc_url: https://keras.io
   dev_url: https://github.com/keras-team/keras
 
 extra:

--- a/tensorboard/meta.yaml
+++ b/tensorboard/meta.yaml
@@ -33,7 +33,7 @@ requirements:
     - setuptools >=41.0.0
     - tensorboard-data-server >=0.6.0,<0.7.0
     - tensorboard-plugin-wit >=1.6.0
-    - werkzeug >=0.11.15
+    - werkzeug >=1.0.1
     - wheel >=0.26
 
 test:

--- a/tensorboard/meta.yaml
+++ b/tensorboard/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorboard" %}
-{% set version = "2.8.0" %}
+{% set version = "2.9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/py3/t/tensorboard/tensorboard-{{ version }}-py3-none-any.whl
-  sha256: 65a338e4424e9079f2604923bdbe301792adce2ace1be68da6b3ddf005170def
+  sha256: bd78211076dca5efa27260afacfaa96cd05c7db12a6c09cc76a1d6b2987ca621
 
 build:
   number: 0

--- a/tensorflow-estimator/meta.yaml
+++ b/tensorflow-estimator/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorflow-estimator" %}
-{% set version = "2.8.0" %}
+{% set version = "2.9.0" %}
 {% set major_minor = version.rsplit('.', 1)[0] %}
 
 package:
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/py2.py3/t/tensorflow-estimator/tensorflow_estimator-{{ version }}-py2.py3-none-any.whl
-  sha256: bee8e0520c60ae7eaf6ca8cb46c5a9f4b45725531380db8fbe38fcb48478b6bb
+  sha256: e9762bb302f51bc1eb2f35d19f0190a6a2d809d754d5def788c4328fe3746744
 
 build:
   number: 0
@@ -22,13 +22,8 @@ requirements:
     - pip
   run:
     - python
+  run_constrained:
     - tensorflow-base  {{ major_minor }}.*
-
-test:
-  imports:
-    # ImportError: /lib64/libc.so.6: version `GLIBC_2.17' not found
-    - numpy
-    # TODO (tkoch): import something meaningful or test manually.
 
 about:
   home: https://www.tensorflow.org/guide/estimator


### PR DESCRIPTION
Upgrading `tensorflow` to `2.9.1` requires version `2.9.0` for `keras`, `tensorflow-estimator` and `tensorboard`, which this PR tries to address.

Concourse for `keras`: https://concourse.build.corp.continuum.io/teams/main/pipelines/keras
(**NOTE**: This fails on certain platforms because of the issue described [here](https://anaconda.slack.com/archives/C02K52E033M/p1659993348778199)).

Concourse for `tensorboard`: https://concourse.build.corp.continuum.io/teams/main/pipelines/tensorboard

Concourse for `tensorflow-estimator`: https://concourse.build.corp.continuum.io/teams/main/pipelines/tensorflow-estimator

`keras` and `tensorflow-estimator` need `tensorflow` as a `run_constrained` dependency since `tensorflow` doesn't have a build with that version number (because it requires `keras`...a cyclic dependency of sorts).

(NOTE: Keeping the base branch `master-2.8.2` for now, as it is the closest to where we want to be when we are ready to upgrade to `2.9.1`.)